### PR TITLE
Promote `Digest` from type alias to a real type & some cleanup and documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,8 +28,6 @@ use std::mem;
 use std::ops;
 use std::fmt;
 
-// pub type Digest = [u8; 16];
-
 /// A digest.
 ///
 /// The raw data of the digest can be accessed with the `raw_data()` method.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,18 +97,18 @@ impl Context {
     }
 
     /// Consume data.
-    pub fn consume(&mut self, data: &[u8]) {
+    pub fn consume<A: AsRef<[u8]>>(&mut self, data: A) {
         let mut input: [u32; 16] = unsafe { mem::uninitialized() };
         let mut k = ((self.handled[0] >> 3) & 0x3F) as usize;
 
-        let length = data.len() as u32;
+        let length = data.as_ref().len() as u32;
         if (self.handled[0] + (length << 3)) < self.handled[0] {
             self.handled[1] += 1;
         }
         self.handled[0] += length << 3;
         self.handled[1] += length >> 29;
 
-        for &value in data {
+        for &value in data.as_ref() {
             self.input[k] = value;
             k += 1;
             if k != 0x40 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,10 +211,13 @@ impl Clone for Context {
 }
 
 /// Compute the digest of data.
+///
+/// This is a shorthand for manually creating a `Context`, writing data
+/// into it and calling `compute()`.
 #[inline]
-pub fn compute(data: &[u8]) -> Digest {
+pub fn compute<A: AsRef<[u8]>>(data: A) -> Digest {
     let mut context = Context::new();
-    context.consume(data);
+    context.consume(data.as_ref());
     context.compute()
 }
 
@@ -376,16 +379,10 @@ fn transform(buffer: &mut [u32; 4], input: &[u32; 16]) {
 
 #[cfg(test)]
 mod tests {
-    macro_rules! digest(
-        ($string:expr) => ({
-            let mut context = ::Context::new();
-            context.consume($string.as_bytes());
-            format!("{:x}", context.compute())
-        });
-    );
-
     #[test]
     fn compute() {
+        use super::*;
+
         let inputs = [
             "",
             "a",
@@ -407,7 +404,8 @@ mod tests {
         ];
 
         for (input, &output) in inputs.iter().zip(outputs.iter()) {
-            assert_eq!(digest!(input), output);
+            let digest = compute(input);
+            assert_eq!(format!("{:x}", digest), output);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,10 @@
 //! );
 //! ```
 //!
+//! If you want to hash a lot of data, consider using the `Context` type to
+//! avoid loading all of the data into memory at once.
+//!
+//!
 //! [1]: https://en.wikipedia.org/wiki/MD5
 
 // The implementation is based on:
@@ -86,6 +90,14 @@ impl_fmt!(UpperHex, "{:02X}");
 
 
 /// A context.
+///
+/// This type allows to stream the hash calculation, instead of doing it
+/// on one big chunk of memory. You can just call the `consume()` method
+/// whenever new data is available. When all data has been fed into the
+/// context, you can call `compute()` to get the resulting digest.
+///
+/// This context has a fixed size and will not allocate any memory on the
+/// heap!
 #[derive(Copy)]
 pub struct Context {
   handled: [u32; 2],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,15 +20,6 @@ use std::ops::{Deref, Index};
 /// A digest.
 pub struct Digest(pub [u8; 16]);
 
-impl Digest {
-    /// Returns the raw data as fixed-size array. Of course, you can also
-    /// just access the field via `digest.0`, but this method is more
-    /// descriptive.
-    pub fn raw_data(&self) -> [u8; 16] {
-        self.0
-    }
-}
-
 impl Deref for Digest {
     type Target = [u8; 16];
     fn deref(&self) -> &Self::Target {


### PR DESCRIPTION
Hi!

I recently used your library for *Advent of Code* and noticed that handling the `Digest` type was a bit clumsy for my use-case. So I tried to improve the API a bit, by promoting it to a real type. Please see the first commit for detailed information and open questions.

I also made the`compute()` function more general and added documentation. However, I didn't touch or look at any of the "real MD5 code", because I don't know anything about it. 

What do you think of the changes? Of course, you can reject all changes or just accept parts of it! And I can improve certain things still. Also: if my comments/docs contain non-perfect English, please don't hesitate to tell me!

I have one additional suggestion: renaming `Context::compute()` to `Context::finalize()`. I think `finalize()` is clearer.