### PR TITLE
Added a reset method to save on object creation.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,6 +170,13 @@ impl Context {
 
         Digest(digest)
     }
+
+    /// Resets the hasher to the starting state
+    #[inline]
+    pub fn reset(&mut self) {
+        self.handled = [0, 0];
+        self.buffer = [0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476];
+    }
 }
 
 impl Clone for Context {
@@ -389,6 +396,14 @@ mod tests {
 
         for (input, &output) in inputs.iter().zip(outputs.iter()) {
             assert_eq!(format!("{:x}", ::compute(input)), output);
+        }
+
+        let mut context = ::Context::new();
+        for (input, &output) in inputs.iter().zip(outputs.iter()) {
+            context.reset();
+            context.consume(input);
+            assert_eq!(format!("{:x}", context.compute()), output);
+
         }
     }
 


### PR DESCRIPTION
Basically, I have a case where I am repeatedly using this digest, and it's slightly faster to reset the digest rather than create a new one.  At minimum, I think adding this method does no harm.