### PR TITLE
Remove unnecessary unsafe blocks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 // The implementation is based on:
 // http://people.csail.mit.edu/rivest/Md5.c
 
-use std::{fmt, mem};
+use std::fmt;
 use std::convert::From;
 use std::io::{Result, Write};
 use std::ops::{Deref, DerefMut};
@@ -101,13 +101,13 @@ impl Context {
         Context {
             handled: [0, 0],
             buffer: [0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476],
-            input: unsafe { mem::uninitialized() },
+            input: [0u8; 64],
         }
     }
 
     /// Consume data.
     pub fn consume<T: AsRef<[u8]>>(&mut self, data: T) {
-        let mut input: [u32; 16] = unsafe { mem::uninitialized() };
+        let mut input = [0u32; 16];
         let mut k = ((self.handled[0] >> 3) & 0x3F) as usize;
 
         let data = data.as_ref();
@@ -139,7 +139,7 @@ impl Context {
 
     /// Finalize and return the digest.
     pub fn compute(mut self) -> Digest {
-        let mut input: [u32; 16] = unsafe { mem::uninitialized() };
+        let mut input = [0u32; 16];
         let k = ((self.handled[0] >> 3) & 0x3F) as usize;
 
         input[14] = self.handled[0];
@@ -157,7 +157,7 @@ impl Context {
         }
         transform(&mut self.buffer, &input);
 
-        let mut digest: [u8; 16] = unsafe { mem::uninitialized() };
+        let mut digest = [0u8; 16];
 
         let mut j = 0;
         for i in 0..4 {


### PR DESCRIPTION
`unsafe` blocks should not be used lightly, and the `mem::uninitialized` docs mention that initializing memory with a default value should be considered first.

This patch does not affect performance on my machine:

With `unsafe`:
```
$ cargo bench
    Finished release [optimized] target(s) in 0.00s                                                             
     Running target/release/deps/md5-0fe8f68af9847d92

running 2 tests
test tests::compute ... ignored
test tests::index ... ignored

test result: ok. 0 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out

     Running target/release/deps/lib-15f5e380c62158f8

running 4 tests
test compute_0001000 ... bench:       2,123 ns/iter (+/- 17)
test compute_0010000 ... bench:      20,706 ns/iter (+/- 163)
test compute_0100000 ... bench:     205,607 ns/iter (+/- 5,620)
test compute_1000000 ... bench:   2,005,851 ns/iter (+/- 20,207)

test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured; 0 filtered out
```

Without `unsafe`:
```
$ cargo bench
    Finished release [optimized] target(s) in 0.00s                                                             
     Running target/release/deps/md5-0fe8f68af9847d92

running 2 tests
test tests::compute ... ignored
test tests::index ... ignored

test result: ok. 0 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out

     Running target/release/deps/lib-15f5e380c62158f8

running 4 tests
test compute_0001000 ... bench:       2,139 ns/iter (+/- 48)
test compute_0010000 ... bench:      20,772 ns/iter (+/- 148)
test compute_0100000 ... bench:     200,449 ns/iter (+/- 217)
test compute_1000000 ... bench:   2,005,384 ns/iter (+/- 9,365)

test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured; 0 filtered out
```