### PR TITLE
Add Hash, Serialize and Deserialize traits implementations for Digest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ repository = "https://github.com/stainless-steel/md5"
 readme = "README.md"
 categories = ["algorithms", "cryptography"]
 keywords = ["checksum", "digest", "hash", "md5"]
+[dependencies]
+serde = "1"
+serde_derive = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,10 @@
 // The implementation is based on:
 // http://people.csail.mit.edu/rivest/Md5.c
 
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+
 use std::fmt;
 use std::convert::From;
 use std::io::{Result, Write};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ use std::io::{Result, Write};
 use std::ops::{Deref, DerefMut};
 
 /// A digest.
-#[derive(Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct Digest(pub [u8; 16]);
 
 impl Deref for Digest {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,12 @@ use std::ops::{Deref, DerefMut};
 #[derive(Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct Digest(pub [u8; 16]);
 
+impl fmt::Debug for Digest {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        fmt::UpperHex::fmt(self, formatter)
+    }
+}
+
 impl Deref for Digest {
     type Target = [u8; 16];
 


### PR DESCRIPTION
To use Digest as a key for HashMap, need to implement Hash trait. Default derive would do.
To serialize and deserialize Digest with, derive default implementations for required traits.
Debug trait implementation uses UpperHex.