### PR TITLE
Speed up the computation process

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,9 +187,9 @@ fn consume(
     let mut done = 0;
     let mut left = data.len();
     while left > 0 {
-        let count = if k + left <= 0x40 { left } else { 0x40 - k };
+        let count = if k + left <= 64 { left } else { 64 - k };
         unsafe { ptr::copy_nonoverlapping(&data[done], &mut buffer[k], count) };
-        k = (k + count) % 0x40;
+        k = (k + count) % 64;
         if k > 0 { break }
         done += count;
         left -= count;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,8 +133,8 @@ impl Context {
         let count = unsafe { mem::transmute::<&[u32; 2], &[u8; 8]>(&count) };
         consume(&mut self, padding);
         consume(&mut self, count);
-        for i in 0..4 {
-            self.state[i] = self.state[i].to_le();
+        for value in self.state.iter_mut() {
+            *value = value.to_le();
         }
         Digest(unsafe { mem::transmute(self.state) })
     }
@@ -183,13 +183,13 @@ fn consume(
         count[1] = count[1].wrapping_add(1);
     }
     count[1] = count[1].wrapping_add(length >> 29);
-    for &value in data {
-        buffer[k] = value;
+    for value in data {
+        buffer[k] = *value;
         k += 1;
         if k == 0x40 {
             let buffer = unsafe { mem::transmute::<&mut [u8; 64], &mut [u32; 16]>(buffer) };
-            for i in 0..16 {
-                buffer[i] = u32::from_le(buffer[i]);
+            for value in buffer.iter_mut() {
+                *value = u32::from_le(*value);
             }
             transform(state, &buffer);
             k = 0;


### PR DESCRIPTION
## Tasks

* [x] Make use of `from_le` and `to_le`
* [x] Get rid of auxiliary buffers
* [x] Do not initialize `buffer`
* [x] Make use of `copy_nonoverlapping`
* [ ] ~Make use of `cfg!(target_endian = "…")`~

## Before

```
rustc 1.35.0-nightly (befeeb7c0 2019-03-30)
rustup 1.17.0 (069c88ed6 2019-03-05)
cargo 1.35.0-nightly (63231f438 2019-03-27)

test compute_0001000 ... bench:       3,006 ns/iter (+/- 72)
test compute_0010000 ... bench:      29,242 ns/iter (+/- 594)
test compute_0100000 ... bench:     289,585 ns/iter (+/- 9,280)
test compute_1000000 ... bench:   2,922,448 ns/iter (+/- 88,887)
```

## After

```
rustc 1.35.0-nightly (befeeb7c0 2019-03-30)
rustup 1.17.0 (069c88ed6 2019-03-05)
cargo 1.35.0-nightly (63231f438 2019-03-27)

test compute_0001000 ... bench:       2,420 ns/iter (+/- 49)
test compute_0010000 ... bench:      23,645 ns/iter (+/- 290)
test compute_0100000 ... bench:     235,915 ns/iter (+/- 5,451)
test compute_1000000 ... bench:   2,362,815 ns/iter (+/- 41,799)
```