### PR TITLE
Re-implementing MD5 using u64 values

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ const SHIFTS: [u32; 64] = [
 ];
 
 // f64::floor(power * f64::abs(f64::sin(i as f64 + 1.0))) as u32
-const SIN_CONSTS: [u32; 64] = [
+const SINES: [u32; 64] = [
     0xd76aa478, 0xe8c7b756, 0x242070db, 0xc1bdceee, 0xf57c0faf, 0x4787c62a, 0xa8304613, 0xfd469501,
     0x698098d8, 0x8b44f7af, 0xffff5bb1, 0x895cd7be, 0x6b901122, 0xfd987193, 0xa679438e, 0x49b40821,
     0xf61e2562, 0xc040b340, 0x265e5a51, 0xe9b6c7aa, 0xd62f105d, 0x02441453, 0xd8a1e681, 0xe7d3fbc8,
@@ -189,7 +189,7 @@ fn transform(hash_values: &mut [u32; 4], buffer: &[u8; 64]) {
         |a: &mut u32, b: &mut u32, c: &mut u32, d: &mut u32, mut f: u32, g: usize, i: usize| {
             f = f
                 .wrapping_add(*a)
-                .wrapping_add(SIN_CONSTS[i])
+                .wrapping_add(SINES[i])
                 .wrapping_add(segments[g]);
             *a = *d;
             *d = *c;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,11 +37,6 @@ use core::convert;
 use core::fmt;
 use core::ops;
 
-#[cfg(feature = "std")]
-use core::io;
-
-/// A digest.
-#[derive(Clone, Copy, Eq, Hash, PartialEq)]
 pub struct Digest(pub [u8; 16]);
 
 impl convert::From<Digest> for [u8; 16] {
@@ -90,282 +85,142 @@ macro_rules! implement {
 implement!(LowerHex, "{:02x}");
 implement!(UpperHex, "{:02X}");
 
-/// A context.
-#[derive(Clone)]
-pub struct Context {
-    buffer: [u8; 64],
-    count: [u32; 2],
-    state: [u32; 4],
-}
+// Constants
+const PADDING: [u8; 64] = {
+    let mut padding = [0; 64];
+    padding[0] = 0x80;
+    padding
+};
 
-const PADDING: [u8; 64] = [
-    0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+#[rustfmt::skip]
+const SHIFTS: [u32; 64] = [
+    07, 12, 17, 22, 07, 12, 17, 22, 07, 12, 17, 22, 07, 12, 17, 22, // Round 1
+    05, 09, 14, 20, 05, 09, 14, 20, 05, 09, 14, 20, 05, 09, 14, 20, // Round 2
+    04, 11, 16, 23, 04, 11, 16, 23, 04, 11, 16, 23, 04, 11, 16, 23, // Round 3
+    06, 10, 15, 21, 06, 10, 15, 21, 06, 10, 15, 21, 06, 10, 15, 21, // Round 4
 ];
 
-impl Context {
-    /// Create a context for computing a digest.
-    #[inline]
-    pub fn new() -> Context {
-        Context {
-            buffer: [0; 64],
-            count: [0, 0],
-            state: [0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476],
-        }
-    }
+// f64::floor(power * f64::abs(f64::sin(i as f64 + 1.0))) as u32
+const SIN_CONSTS: [u32; 64] = [
+    0xd76aa478, 0xe8c7b756, 0x242070db, 0xc1bdceee, 0xf57c0faf, 0x4787c62a, 0xa8304613, 0xfd469501,
+    0x698098d8, 0x8b44f7af, 0xffff5bb1, 0x895cd7be, 0x6b901122, 0xfd987193, 0xa679438e, 0x49b40821,
+    0xf61e2562, 0xc040b340, 0x265e5a51, 0xe9b6c7aa, 0xd62f105d, 0x02441453, 0xd8a1e681, 0xe7d3fbc8,
+    0x21e1cde6, 0xc33707d6, 0xf4d50d87, 0x455a14ed, 0xa9e3e905, 0xfcefa3f8, 0x676f02d9, 0x8d2a4c8a,
+    0xfffa3942, 0x8771f681, 0x6d9d6122, 0xfde5380c, 0xa4beea44, 0x4bdecfa9, 0xf6bb4b60, 0xbebfbc70,
+    0x289b7ec6, 0xeaa127fa, 0xd4ef3085, 0x04881d05, 0xd9d4d039, 0xe6db99e5, 0x1fa27cf8, 0xc4ac5665,
+    0xf4292244, 0x432aff97, 0xab9423a7, 0xfc93a039, 0x655b59c3, 0x8f0ccc92, 0xffeff47d, 0x85845dd1,
+    0x6fa87e4f, 0xfe2ce6e0, 0xa3014314, 0x4e0811a1, 0xf7537e82, 0xbd3af235, 0x2ad7d2bb, 0xeb86d391,
+];
 
-    /// Consume data.
-    #[cfg(target_pointer_width = "32")]
-    #[inline]
-    pub fn consume<T: AsRef<[u8]>>(&mut self, data: T) {
-        consume(self, data.as_ref());
-    }
+const START_HASH_VALUES: [u32; 4] = [0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476];
 
-    /// Consume data.
-    #[cfg(target_pointer_width = "64")]
-    pub fn consume<T: AsRef<[u8]>>(&mut self, data: T) {
-        for chunk in data.as_ref().chunks(core::u32::MAX as usize) {
-            consume(self, chunk);
-        }
-    }
-
-    /// Finalize and return the digest.
-    pub fn compute(mut self) -> Digest {
-        let mut input = [0u32; 16];
-        let k = ((self.count[0] >> 3) & 0x3f) as usize;
-        input[14] = self.count[0];
-        input[15] = self.count[1];
-        consume(
-            &mut self,
-            &PADDING[..(if k < 56 { 56 - k } else { 120 - k })],
-        );
-        let mut j = 0;
-        for i in 0..14 {
-            input[i] = ((self.buffer[j + 3] as u32) << 24) |
-                       ((self.buffer[j + 2] as u32) << 16) |
-                       ((self.buffer[j + 1] as u32) <<  8) |
-                       ((self.buffer[j    ] as u32)      );
-            j += 4;
-        }
-        transform(&mut self.state, &input);
-        let mut digest = [0u8; 16];
-        let mut j = 0;
-        for i in 0..4 {
-            digest[j    ] = ((self.state[i]      ) & 0xff) as u8;
-            digest[j + 1] = ((self.state[i] >>  8) & 0xff) as u8;
-            digest[j + 2] = ((self.state[i] >> 16) & 0xff) as u8;
-            digest[j + 3] = ((self.state[i] >> 24) & 0xff) as u8;
-            j += 4;
-        }
-        Digest(digest)
-    }
-}
-
-impl convert::From<Context> for Digest {
-    #[inline]
-    fn from(context: Context) -> Digest {
-        context.compute()
-    }
-}
-
-#[cfg(feature = "std")]
-impl io::Write for Context {
-    #[inline]
-    fn write(&mut self, data: &[u8]) -> io::Result<usize> {
-        self.consume(data);
-        Ok(data.len())
-    }
-
-    #[inline]
-    fn flush(&mut self) -> io::Result<()> {
-        Ok(())
-    }
-}
-
-/// Compute the digest of data.
-#[inline]
 pub fn compute<T: AsRef<[u8]>>(data: T) -> Digest {
-    let mut context = Context::new();
-    context.consume(data);
-    context.compute()
-}
+    let mut buffer: [u8; 64] = [0; 64];
+    let mut hash_values = START_HASH_VALUES;
+    let mut k = 0;
 
-fn consume(
-    Context {
-        buffer,
-        count,
-        state,
-    }: &mut Context,
-    data: &[u8],
-) {
-    let mut input = [0u32; 16];
-    let mut k = ((count[0] >> 3) & 0x3f) as usize;
-    let length = data.len() as u32;
-    count[0] = count[0].wrapping_add(length << 3);
-    if count[0] < length << 3 {
-        count[1] = count[1].wrapping_add(1);
-    }
-    count[1] = count[1].wrapping_add(length >> 29);
-    for &value in data {
+    for &value in data.as_ref() {
         buffer[k] = value;
         k += 1;
-        if k == 0x40 {
-            let mut j = 0;
-            for i in 0..16 {
-                input[i] = ((buffer[j + 3] as u32) << 24) |
-                           ((buffer[j + 2] as u32) << 16) |
-                           ((buffer[j + 1] as u32) <<  8) |
-                           ((buffer[j    ] as u32)      );
-                j += 4;
-            }
-            transform(state, &input);
+
+        if k == 64 {
+            transform(&mut hash_values, &buffer);
             k = 0;
         }
     }
+
+    if k > 55 {
+        // Not enough space to fit length at the end of the buffer; pad and transform.
+        buffer[k..64].copy_from_slice(&PADDING[..64 - k]);
+        transform(&mut hash_values, &buffer);
+        // Copy across zeros upto the length marker.
+        buffer[..56].copy_from_slice(&PADDING[1..57])
+    } else {
+        // Enough space already; copy across padding.
+        buffer[k..56].copy_from_slice(&PADDING[..56 - k])
+    }
+
+    // Append the data length (in bits) and run the last transform.
+    let mut data_length = (data.as_ref().len() << 3) as u64;
+    let mut i = 0;
+    while i < 8 {
+        buffer[56 + i] = data_length as u8;
+        data_length >>= 8;
+        i += 1;
+    }
+
+    transform(&mut hash_values, &buffer);
+
+    let mut output: [u8; 16] = [0; 16];
+    // Convert hash_values from u32 -> u8s assuming little endian format.
+    for i in 0..16 {
+        output[i] = hash_values[i / 4] as u8;
+        hash_values[i / 4] >>= 8;
+    }
+
+    Digest(output)
 }
 
-fn transform(state: &mut [u32; 4], input: &[u32; 16]) {
-    let (mut a, mut b, mut c, mut d) = (state[0], state[1], state[2], state[3]);
-    macro_rules! add(
-        ($a:expr, $b:expr) => ($a.wrapping_add($b));
-    );
-    macro_rules! rotate(
-        ($x:expr, $n:expr) => (($x << $n) | ($x >> (32 - $n)));
-    );
-    {
-        macro_rules! F(
-            ($x:expr, $y:expr, $z:expr) => (($x & $y) | (!$x & $z));
-        );
-        macro_rules! T(
-            ($a:expr, $b:expr, $c:expr, $d:expr, $x:expr, $s:expr, $ac:expr) => ({
-                $a = add!(add!(add!($a, F!($b, $c, $d)), $x), $ac);
-                $a = rotate!($a, $s);
-                $a = add!($a, $b);
-            });
-        );
-        const S1: u32 =  7;
-        const S2: u32 = 12;
-        const S3: u32 = 17;
-        const S4: u32 = 22;
-        T!(a, b, c, d, input[ 0], S1, 3614090360);
-        T!(d, a, b, c, input[ 1], S2, 3905402710);
-        T!(c, d, a, b, input[ 2], S3,  606105819);
-        T!(b, c, d, a, input[ 3], S4, 3250441966);
-        T!(a, b, c, d, input[ 4], S1, 4118548399);
-        T!(d, a, b, c, input[ 5], S2, 1200080426);
-        T!(c, d, a, b, input[ 6], S3, 2821735955);
-        T!(b, c, d, a, input[ 7], S4, 4249261313);
-        T!(a, b, c, d, input[ 8], S1, 1770035416);
-        T!(d, a, b, c, input[ 9], S2, 2336552879);
-        T!(c, d, a, b, input[10], S3, 4294925233);
-        T!(b, c, d, a, input[11], S4, 2304563134);
-        T!(a, b, c, d, input[12], S1, 1804603682);
-        T!(d, a, b, c, input[13], S2, 4254626195);
-        T!(c, d, a, b, input[14], S3, 2792965006);
-        T!(b, c, d, a, input[15], S4, 1236535329);
+#[inline(always)]
+fn transform(hash_values: &mut [u32; 4], buffer: &[u8; 64]) {
+    let mut segments: [u32; 16] = [0; 16];
+
+    for i in 0..16 {
+        let byte_start = i * 4;
+        segments[i] = ((buffer[byte_start] as u32) << 0)
+            + ((buffer[byte_start + 1] as u32) << 8)
+            + ((buffer[byte_start + 2] as u32) << 16)
+            + ((buffer[byte_start + 3] as u32) << 24);
     }
-    {
-        macro_rules! F(
-            ($x:expr, $y:expr, $z:expr) => (($x & $z) | ($y & !$z));
-        );
-        macro_rules! T(
-            ($a:expr, $b:expr, $c:expr, $d:expr, $x:expr, $s:expr, $ac:expr) => ({
-                $a = add!(add!(add!($a, F!($b, $c, $d)), $x), $ac);
-                $a = rotate!($a, $s);
-                $a = add!($a, $b);
-            });
-        );
-        const S1: u32 =  5;
-        const S2: u32 =  9;
-        const S3: u32 = 14;
-        const S4: u32 = 20;
-        T!(a, b, c, d, input[ 1], S1, 4129170786);
-        T!(d, a, b, c, input[ 6], S2, 3225465664);
-        T!(c, d, a, b, input[11], S3,  643717713);
-        T!(b, c, d, a, input[ 0], S4, 3921069994);
-        T!(a, b, c, d, input[ 5], S1, 3593408605);
-        T!(d, a, b, c, input[10], S2,   38016083);
-        T!(c, d, a, b, input[15], S3, 3634488961);
-        T!(b, c, d, a, input[ 4], S4, 3889429448);
-        T!(a, b, c, d, input[ 9], S1,  568446438);
-        T!(d, a, b, c, input[14], S2, 3275163606);
-        T!(c, d, a, b, input[ 3], S3, 4107603335);
-        T!(b, c, d, a, input[ 8], S4, 1163531501);
-        T!(a, b, c, d, input[13], S1, 2850285829);
-        T!(d, a, b, c, input[ 2], S2, 4243563512);
-        T!(c, d, a, b, input[ 7], S3, 1735328473);
-        T!(b, c, d, a, input[12], S4, 2368359562);
+
+    let mut hash_a = hash_values[0];
+    let mut hash_b = hash_values[1];
+    let mut hash_c = hash_values[2];
+    let mut hash_d = hash_values[3];
+
+    let mut f: u32;
+    let mut g: usize;
+
+    let cycle_hashes =
+        |a: &mut u32, b: &mut u32, c: &mut u32, d: &mut u32, mut f: u32, g: usize, i: usize| {
+            f = f
+                .wrapping_add(*a)
+                .wrapping_add(SIN_CONSTS[i])
+                .wrapping_add(segments[g]);
+            *a = *d;
+            *d = *c;
+            *c = *b;
+            *b = f.rotate_left(SHIFTS[i]).wrapping_add(*b);
+        };
+
+    for i in 0..16 {
+        f = (hash_b & hash_c) | (!hash_b & hash_d);
+        g = i;
+        cycle_hashes(&mut hash_a, &mut hash_b, &mut hash_c, &mut hash_d, f, g, i);
     }
-    {
-        macro_rules! F(
-            ($x:expr, $y:expr, $z:expr) => ($x ^ $y ^ $z);
-        );
-        macro_rules! T(
-            ($a:expr, $b:expr, $c:expr, $d:expr, $x:expr, $s:expr, $ac:expr) => ({
-                $a = add!(add!(add!($a, F!($b, $c, $d)), $x), $ac);
-                $a = rotate!($a, $s);
-                $a = add!($a, $b);
-            });
-        );
-        const S1: u32 =  4;
-        const S2: u32 = 11;
-        const S3: u32 = 16;
-        const S4: u32 = 23;
-        T!(a, b, c, d, input[ 5], S1, 4294588738);
-        T!(d, a, b, c, input[ 8], S2, 2272392833);
-        T!(c, d, a, b, input[11], S3, 1839030562);
-        T!(b, c, d, a, input[14], S4, 4259657740);
-        T!(a, b, c, d, input[ 1], S1, 2763975236);
-        T!(d, a, b, c, input[ 4], S2, 1272893353);
-        T!(c, d, a, b, input[ 7], S3, 4139469664);
-        T!(b, c, d, a, input[10], S4, 3200236656);
-        T!(a, b, c, d, input[13], S1,  681279174);
-        T!(d, a, b, c, input[ 0], S2, 3936430074);
-        T!(c, d, a, b, input[ 3], S3, 3572445317);
-        T!(b, c, d, a, input[ 6], S4,   76029189);
-        T!(a, b, c, d, input[ 9], S1, 3654602809);
-        T!(d, a, b, c, input[12], S2, 3873151461);
-        T!(c, d, a, b, input[15], S3,  530742520);
-        T!(b, c, d, a, input[ 2], S4, 3299628645);
+
+    for i in 16..32 {
+        f = (hash_d & hash_b) | (!hash_d & hash_c);
+        g = (5 * i + 1) % 16;
+        cycle_hashes(&mut hash_a, &mut hash_b, &mut hash_c, &mut hash_d, f, g, i);
     }
-    {
-        macro_rules! F(
-            ($x:expr, $y:expr, $z:expr) => ($y ^ ($x | !$z));
-        );
-        macro_rules! T(
-            ($a:expr, $b:expr, $c:expr, $d:expr, $x:expr, $s:expr, $ac:expr) => ({
-                $a = add!(add!(add!($a, F!($b, $c, $d)), $x), $ac);
-                $a = rotate!($a, $s);
-                $a = add!($a, $b);
-            });
-        );
-        const S1: u32 =  6;
-        const S2: u32 = 10;
-        const S3: u32 = 15;
-        const S4: u32 = 21;
-        T!(a, b, c, d, input[ 0], S1, 4096336452);
-        T!(d, a, b, c, input[ 7], S2, 1126891415);
-        T!(c, d, a, b, input[14], S3, 2878612391);
-        T!(b, c, d, a, input[ 5], S4, 4237533241);
-        T!(a, b, c, d, input[12], S1, 1700485571);
-        T!(d, a, b, c, input[ 3], S2, 2399980690);
-        T!(c, d, a, b, input[10], S3, 4293915773);
-        T!(b, c, d, a, input[ 1], S4, 2240044497);
-        T!(a, b, c, d, input[ 8], S1, 1873313359);
-        T!(d, a, b, c, input[15], S2, 4264355552);
-        T!(c, d, a, b, input[ 6], S3, 2734768916);
-        T!(b, c, d, a, input[13], S4, 1309151649);
-        T!(a, b, c, d, input[ 4], S1, 4149444226);
-        T!(d, a, b, c, input[11], S2, 3174756917);
-        T!(c, d, a, b, input[ 2], S3,  718787259);
-        T!(b, c, d, a, input[ 9], S4, 3951481745);
+
+    for i in 32..48 {
+        f = hash_b ^ hash_c ^ hash_d;
+        g = (3 * i + 5) % 16;
+        cycle_hashes(&mut hash_a, &mut hash_b, &mut hash_c, &mut hash_d, f, g, i);
     }
-    state[0] = add!(state[0], a);
-    state[1] = add!(state[1], b);
-    state[2] = add!(state[2], c);
-    state[3] = add!(state[3], d);
+
+    for i in 48..64 {
+        f = hash_c ^ (hash_b | !hash_d);
+        g = (7 * i) % 16;
+        cycle_hashes(&mut hash_a, &mut hash_b, &mut hash_c, &mut hash_d, f, g, i);
+    }
+
+    hash_values[0] = hash_values[0].wrapping_add(hash_a);
+    hash_values[1] = hash_values[1].wrapping_add(hash_b);
+    hash_values[2] = hash_values[2].wrapping_add(hash_c);
+    hash_values[3] = hash_values[3].wrapping_add(hash_d);
 }
 
 #[cfg(test)]
@@ -403,33 +258,5 @@ mod tests {
         assert_eq!(digest[0], 0x90);
         assert_eq!(&digest[0], &0x90);
         assert_eq!(&mut digest[0], &mut 0x90);
-    }
-
-    #[test]
-    fn overflow_count() {
-        use std::io::prelude::Write;
-        let data = vec![0; 8 * 1024 * 1024];
-        let mut context = ::Context::new();
-        for _ in 0..64 {
-            context.write(&data).unwrap();
-        }
-        assert_eq!(
-            format!("{:x}", context.compute()),
-            "aa559b4e3523a6c931f08f4df52d58f2"
-        );
-    }
-
-    #[test]
-    #[cfg(target_pointer_width = "64")]
-    fn overflow_length() {
-        use std::io::prelude::Write;
-        use std::u32::MAX;
-        let data = vec![0; MAX as usize + 1];
-        let mut context = ::Context::new();
-        context.write(&data).unwrap();
-        assert_eq!(
-            format!("{:x}", context.compute()),
-            "c9a5a6878d97b48cc965c1e41859f034"
-        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,6 @@ macro_rules! implement {
 implement!(LowerHex, "{:02x}");
 implement!(UpperHex, "{:02X}");
 
-// Constants
 const PADDING: [u8; 64] = {
     let mut padding = [0; 64];
     padding[0] = 0x80;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,11 @@ use core::convert;
 use core::fmt;
 use core::ops;
 
+#[cfg(feature = "std")]
+use core::io;
+
+/// A digest.
+#[derive(Clone, Copy, Eq, Hash, PartialEq)]
 pub struct Digest(pub [u8; 16]);
 
 impl convert::From<Digest> for [u8; 16] {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,6 +118,7 @@ const SINES: [u32; 64] = [
 
 const START_HASH_VALUES: [u32; 4] = [0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476];
 
+/// Consume data.
 pub fn compute<T: AsRef<[u8]>>(data: T) -> Digest {
     let mut buffer: [u8; 64] = [0; 64];
     let mut hash_values = START_HASH_VALUES;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,9 +91,9 @@ implement!(LowerHex, "{:02x}");
 implement!(UpperHex, "{:02X}");
 
 const PADDING: [u8; 64] = {
-    let mut padding = [0; 64];
-    padding[0] = 0x80;
-    padding
+    let mut data = [0; 64];
+    data[0] = 0x80;
+    data
 };
 
 #[rustfmt::skip]


### PR DESCRIPTION
A re-implementation of the MD5 calculation using native u64 to avoid manual arithmetic.

Refactor of multiple stretches of code including large amounts of hard-coding e.g. permuting through a, b, c, d etc. within T! macros.

Removal of Context struct and tests which were reliant on it.

Remaining tests pass, and benchmarks show new code is ~20% faster than existing.

Closes #20.