### PR TITLE
Refactor the implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ authors = [
     "Lukas Kalbertodt <lukas.kalbertodt@gmail.com>",
     "Nathan Musoke <nathan.musoke@gmail.com>",
     "Scott Mabin <scott@mabez.dev>",
+    "Thomas Hamilton <thomas@lambdadtd.com>",
     "Tony Arcieri <bascule@gmail.com>",
     "Wim de With <register@dewith.io>",
     "Yosef Dinerstein <yosefdi@gmail.com>",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -261,19 +261,19 @@ fn transform(state: &mut [u32; 4], buffer: &[u8; 64]) {
 }
 
 #[inline(always)]
-fn construct(buffer: &[u8; 64]) -> [u32; 16] {
+fn construct(data: &[u8; 64]) -> [u32; 16] {
     let mut value: [u32; 16] = [0; 16];
-    for i in 0..16 {
-        value[i] = u32::from_le_bytes(buffer[4 * i..4 * (i + 1)].try_into().unwrap());
+    for (i, chunk) in data.chunks(4).enumerate() {
+        value[i] = u32::from_le_bytes(chunk.try_into().unwrap());
     }
     value
 }
 
 #[inline(always)]
-fn destruct(state: [u32; 4]) -> [u8; 16] {
+fn destruct(data: [u32; 4]) -> [u8; 16] {
     let mut value: [u8; 16] = [0; 16];
-    for i in 0..4 {
-        value[4 * i..4 * (i + 1)].copy_from_slice(&state[i].to_le_bytes());
+    for (i, chunk) in value.chunks_mut(4).enumerate() {
+        chunk.copy_from_slice(&data[i].to_le_bytes());
     }
     value
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,16 +86,37 @@ implement!(UpperHex, "{:02X}");
 #[derive(Clone)]
 pub struct Context {
     buffer: [u8; 64],
-    count: u64,
+    count: [u32; 2],
     state: [u32; 4],
 }
 
-const PADDING: [u8; 64] = [
-    0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+const PADDING: [u8; 64] = {
+    let mut data = [0; 64];
+    data[0] = 0x80;
+    data
+};
+
+#[rustfmt::skip]
+const SHIFTS: [u32; 64] = [
+    07, 12, 17, 22, 07, 12, 17, 22, 07, 12, 17, 22, 07, 12, 17, 22, // Round 1
+    05, 09, 14, 20, 05, 09, 14, 20, 05, 09, 14, 20, 05, 09, 14, 20, // Round 2
+    04, 11, 16, 23, 04, 11, 16, 23, 04, 11, 16, 23, 04, 11, 16, 23, // Round 3
+    06, 10, 15, 21, 06, 10, 15, 21, 06, 10, 15, 21, 06, 10, 15, 21, // Round 4
 ];
+
+// f64::floor(power * f64::abs(f64::sin(i as f64 + 1.0))) as u32
+const SINES: [u32; 64] = [
+    0xd76aa478, 0xe8c7b756, 0x242070db, 0xc1bdceee, 0xf57c0faf, 0x4787c62a, 0xa8304613, 0xfd469501,
+    0x698098d8, 0x8b44f7af, 0xffff5bb1, 0x895cd7be, 0x6b901122, 0xfd987193, 0xa679438e, 0x49b40821,
+    0xf61e2562, 0xc040b340, 0x265e5a51, 0xe9b6c7aa, 0xd62f105d, 0x02441453, 0xd8a1e681, 0xe7d3fbc8,
+    0x21e1cde6, 0xc33707d6, 0xf4d50d87, 0x455a14ed, 0xa9e3e905, 0xfcefa3f8, 0x676f02d9, 0x8d2a4c8a,
+    0xfffa3942, 0x8771f681, 0x6d9d6122, 0xfde5380c, 0xa4beea44, 0x4bdecfa9, 0xf6bb4b60, 0xbebfbc70,
+    0x289b7ec6, 0xeaa127fa, 0xd4ef3085, 0x04881d05, 0xd9d4d039, 0xe6db99e5, 0x1fa27cf8, 0xc4ac5665,
+    0xf4292244, 0x432aff97, 0xab9423a7, 0xfc93a039, 0x655b59c3, 0x8f0ccc92, 0xffeff47d, 0x85845dd1,
+    0x6fa87e4f, 0xfe2ce6e0, 0xa3014314, 0x4e0811a1, 0xf7537e82, 0xbd3af235, 0x2ad7d2bb, 0xeb86d391,
+];
+
+const START_HASH_VALUES: [u32; 4] = [0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476];
 
 impl Context {
     /// Create a context for computing a digest.
@@ -103,48 +124,29 @@ impl Context {
     pub fn new() -> Context {
         Context {
             buffer: [0; 64],
-            count: 0,
-            state: [0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476],
+            count: [0, 0],
+            state: START_HASH_VALUES,
         }
     }
 
     /// Consume data.
     #[inline]
     pub fn consume<T: AsRef<[u8]>>(&mut self, data: T) {
-        consume(self, data.as_ref());
+        consume_data(self, data.as_ref());
     }
 
     /// Finalize and return the digest.
-    #[rustfmt::skip]
-    #[allow(clippy::double_parens, clippy::needless_range_loop)]
     pub fn finalize(mut self) -> Digest {
-        let mut input = [0u32; 16];
-        let k = ((self.count >> 3) & 0x3f) as usize;
-        input[14] = self.count as u32;
-        input[15] = (self.count >> 32) as u32;
-        consume(
-            &mut self,
-            &PADDING[..(if k < 56 { 56 - k } else { 120 - k })],
-        );
-        let mut j = 0;
-        for i in 0..14 {
-            input[i] = ((self.buffer[j + 3] as u32) << 24) |
-                       ((self.buffer[j + 2] as u32) << 16) |
-                       ((self.buffer[j + 1] as u32) <<  8) |
-                       ((self.buffer[j    ] as u32)      );
-            j += 4;
+        consume_final_bits(&mut self);
+
+        let mut output: [u8; 16] = [0; 16];
+        // Convert hash_values from u32 -> u8s assuming little endian format.
+        for i in 0..16 {
+            output[i] = self.state[i / 4] as u8;
+            self.state[i / 4] >>= 8;
         }
-        transform(&mut self.state, &input);
-        let mut digest = [0u8; 16];
-        let mut j = 0;
-        for i in 0..4 {
-            digest[j    ] = ((self.state[i]      ) & 0xff) as u8;
-            digest[j + 1] = ((self.state[i] >>  8) & 0xff) as u8;
-            digest[j + 2] = ((self.state[i] >> 16) & 0xff) as u8;
-            digest[j + 3] = ((self.state[i] >> 24) & 0xff) as u8;
-            j += 4;
-        }
-        Digest(digest)
+
+        Digest(output)
     }
 
     /// Finalize and return the digest.
@@ -191,9 +193,7 @@ pub fn compute<T: AsRef<[u8]>>(data: T) -> Digest {
     context.finalize()
 }
 
-#[rustfmt::skip]
-#[allow(clippy::double_parens, clippy::needless_range_loop)]
-fn consume(
+fn consume_data(
     Context {
         buffer,
         count,
@@ -201,168 +201,116 @@ fn consume(
     }: &mut Context,
     data: &[u8],
 ) {
-    let mut input = [0u32; 16];
-    let mut k = ((*count >> 3) & 0x3f) as usize;
-    *count = count.wrapping_add((data.len() as u64) << 3);
-    for &value in data {
-        buffer[k] = value;
-        k += 1;
-        if k == 0x40 {
-            let mut j = 0;
-            for i in 0..16 {
-                input[i] = ((buffer[j + 3] as u32) << 24) |
-                           ((buffer[j + 2] as u32) << 16) |
-                           ((buffer[j + 1] as u32) <<  8) |
-                           ((buffer[j    ] as u32)      );
-                j += 4;
-            }
-            transform(state, &input);
-            k = 0;
+    let mut cursor = count[0] % 64;
+
+    for chunk in data {
+        buffer[cursor as usize] = *chunk;
+        cursor += 1;
+
+        if cursor == 64 {
+            transform(state, &buffer);
+            cursor = 0;
         }
     }
+
+    let current_count = count[0] as u64 | ((count[1] as u64) << 32);
+    let additional_count = data.len() as u64;
+    let new_count = current_count.wrapping_add(additional_count);
+
+    count[0] = new_count as u32;
+    count[1] = (new_count >> 32) as u32;
 }
 
-#[rustfmt::skip]
-fn transform(state: &mut [u32; 4], input: &[u32; 16]) {
-    let (mut a, mut b, mut c, mut d) = (state[0], state[1], state[2], state[3]);
-    macro_rules! add(
-        ($a:expr, $b:expr) => ($a.wrapping_add($b));
-    );
-    macro_rules! rotate(
-        ($x:expr, $n:expr) => (($x << $n) | ($x >> (32 - $n)));
-    );
-    {
-        macro_rules! F(
-            ($x:expr, $y:expr, $z:expr) => (($x & $y) | (!$x & $z));
-        );
-        macro_rules! T(
-            ($a:expr, $b:expr, $c:expr, $d:expr, $x:expr, $s:expr, $ac:expr) => ({
-                $a = add!(add!(add!($a, F!($b, $c, $d)), $x), $ac);
-                $a = rotate!($a, $s);
-                $a = add!($a, $b);
-            });
-        );
-        const S1: u32 =  7;
-        const S2: u32 = 12;
-        const S3: u32 = 17;
-        const S4: u32 = 22;
-        T!(a, b, c, d, input[ 0], S1, 3614090360);
-        T!(d, a, b, c, input[ 1], S2, 3905402710);
-        T!(c, d, a, b, input[ 2], S3,  606105819);
-        T!(b, c, d, a, input[ 3], S4, 3250441966);
-        T!(a, b, c, d, input[ 4], S1, 4118548399);
-        T!(d, a, b, c, input[ 5], S2, 1200080426);
-        T!(c, d, a, b, input[ 6], S3, 2821735955);
-        T!(b, c, d, a, input[ 7], S4, 4249261313);
-        T!(a, b, c, d, input[ 8], S1, 1770035416);
-        T!(d, a, b, c, input[ 9], S2, 2336552879);
-        T!(c, d, a, b, input[10], S3, 4294925233);
-        T!(b, c, d, a, input[11], S4, 2304563134);
-        T!(a, b, c, d, input[12], S1, 1804603682);
-        T!(d, a, b, c, input[13], S2, 4254626195);
-        T!(c, d, a, b, input[14], S3, 2792965006);
-        T!(b, c, d, a, input[15], S4, 1236535329);
+fn consume_final_bits(
+    Context {
+        buffer,
+        count,
+        state,
+    }: &mut Context,
+) {
+    let cursor = (count[0] % 64) as usize;
+
+    if cursor > 55 {
+        // Not enough space to fit length at the end of the buffer; pad and transform.
+        buffer[cursor..64].copy_from_slice(&PADDING[..64 - cursor]);
+        transform(state, &buffer);
+        // Copy across zeros upto the length marker.
+        buffer[0..56].copy_from_slice(&PADDING[1..57])
+    } else {
+        // Enough space already; copy across padding.
+        buffer[cursor..56].copy_from_slice(&PADDING[..56 - cursor])
     }
-    {
-        macro_rules! F(
-            ($x:expr, $y:expr, $z:expr) => (($x & $z) | ($y & !$z));
-        );
-        macro_rules! T(
-            ($a:expr, $b:expr, $c:expr, $d:expr, $x:expr, $s:expr, $ac:expr) => ({
-                $a = add!(add!(add!($a, F!($b, $c, $d)), $x), $ac);
-                $a = rotate!($a, $s);
-                $a = add!($a, $b);
-            });
-        );
-        const S1: u32 =  5;
-        const S2: u32 =  9;
-        const S3: u32 = 14;
-        const S4: u32 = 20;
-        T!(a, b, c, d, input[ 1], S1, 4129170786);
-        T!(d, a, b, c, input[ 6], S2, 3225465664);
-        T!(c, d, a, b, input[11], S3,  643717713);
-        T!(b, c, d, a, input[ 0], S4, 3921069994);
-        T!(a, b, c, d, input[ 5], S1, 3593408605);
-        T!(d, a, b, c, input[10], S2,   38016083);
-        T!(c, d, a, b, input[15], S3, 3634488961);
-        T!(b, c, d, a, input[ 4], S4, 3889429448);
-        T!(a, b, c, d, input[ 9], S1,  568446438);
-        T!(d, a, b, c, input[14], S2, 3275163606);
-        T!(c, d, a, b, input[ 3], S3, 4107603335);
-        T!(b, c, d, a, input[ 8], S4, 1163531501);
-        T!(a, b, c, d, input[13], S1, 2850285829);
-        T!(d, a, b, c, input[ 2], S2, 4243563512);
-        T!(c, d, a, b, input[ 7], S3, 1735328473);
-        T!(b, c, d, a, input[12], S4, 2368359562);
+
+    // Append the data length (in bits) and run the last transform.
+    let mut data_length = (count[0] as u64 | ((count[1] as u64) << 32)) << 3;
+    for i in 56..64 {
+        buffer[i] = data_length as u8;
+        data_length >>= 8;
     }
-    {
-        macro_rules! F(
-            ($x:expr, $y:expr, $z:expr) => ($x ^ $y ^ $z);
-        );
-        macro_rules! T(
-            ($a:expr, $b:expr, $c:expr, $d:expr, $x:expr, $s:expr, $ac:expr) => ({
-                $a = add!(add!(add!($a, F!($b, $c, $d)), $x), $ac);
-                $a = rotate!($a, $s);
-                $a = add!($a, $b);
-            });
-        );
-        const S1: u32 =  4;
-        const S2: u32 = 11;
-        const S3: u32 = 16;
-        const S4: u32 = 23;
-        T!(a, b, c, d, input[ 5], S1, 4294588738);
-        T!(d, a, b, c, input[ 8], S2, 2272392833);
-        T!(c, d, a, b, input[11], S3, 1839030562);
-        T!(b, c, d, a, input[14], S4, 4259657740);
-        T!(a, b, c, d, input[ 1], S1, 2763975236);
-        T!(d, a, b, c, input[ 4], S2, 1272893353);
-        T!(c, d, a, b, input[ 7], S3, 4139469664);
-        T!(b, c, d, a, input[10], S4, 3200236656);
-        T!(a, b, c, d, input[13], S1,  681279174);
-        T!(d, a, b, c, input[ 0], S2, 3936430074);
-        T!(c, d, a, b, input[ 3], S3, 3572445317);
-        T!(b, c, d, a, input[ 6], S4,   76029189);
-        T!(a, b, c, d, input[ 9], S1, 3654602809);
-        T!(d, a, b, c, input[12], S2, 3873151461);
-        T!(c, d, a, b, input[15], S3,  530742520);
-        T!(b, c, d, a, input[ 2], S4, 3299628645);
+
+    transform(state, &buffer);
+}
+
+#[inline(always)]
+fn transform(state: &mut [u32; 4], buffer: &[u8; 64]) {
+    let mut segments: [u32; 16] = [0; 16];
+
+    for i in 0..16 {
+        let byte_start = i * 4;
+        segments[i] = ((buffer[byte_start] as u32) << 0)
+            + ((buffer[byte_start + 1] as u32) << 8)
+            + ((buffer[byte_start + 2] as u32) << 16)
+            + ((buffer[byte_start + 3] as u32) << 24);
     }
-    {
-        macro_rules! F(
-            ($x:expr, $y:expr, $z:expr) => ($y ^ ($x | !$z));
-        );
-        macro_rules! T(
-            ($a:expr, $b:expr, $c:expr, $d:expr, $x:expr, $s:expr, $ac:expr) => ({
-                $a = add!(add!(add!($a, F!($b, $c, $d)), $x), $ac);
-                $a = rotate!($a, $s);
-                $a = add!($a, $b);
-            });
-        );
-        const S1: u32 =  6;
-        const S2: u32 = 10;
-        const S3: u32 = 15;
-        const S4: u32 = 21;
-        T!(a, b, c, d, input[ 0], S1, 4096336452);
-        T!(d, a, b, c, input[ 7], S2, 1126891415);
-        T!(c, d, a, b, input[14], S3, 2878612391);
-        T!(b, c, d, a, input[ 5], S4, 4237533241);
-        T!(a, b, c, d, input[12], S1, 1700485571);
-        T!(d, a, b, c, input[ 3], S2, 2399980690);
-        T!(c, d, a, b, input[10], S3, 4293915773);
-        T!(b, c, d, a, input[ 1], S4, 2240044497);
-        T!(a, b, c, d, input[ 8], S1, 1873313359);
-        T!(d, a, b, c, input[15], S2, 4264355552);
-        T!(c, d, a, b, input[ 6], S3, 2734768916);
-        T!(b, c, d, a, input[13], S4, 1309151649);
-        T!(a, b, c, d, input[ 4], S1, 4149444226);
-        T!(d, a, b, c, input[11], S2, 3174756917);
-        T!(c, d, a, b, input[ 2], S3,  718787259);
-        T!(b, c, d, a, input[ 9], S4, 3951481745);
+
+    let mut hash_a = state[0];
+    let mut hash_b = state[1];
+    let mut hash_c = state[2];
+    let mut hash_d = state[3];
+
+    let mut f: u32;
+    let mut g: usize;
+
+    let cycle_hashes =
+        |a: &mut u32, b: &mut u32, c: &mut u32, d: &mut u32, mut f: u32, g: usize, i: usize| {
+            f = f
+                .wrapping_add(*a)
+                .wrapping_add(SINES[i])
+                .wrapping_add(segments[g]);
+            *a = *d;
+            *d = *c;
+            *c = *b;
+            *b = f.rotate_left(SHIFTS[i]).wrapping_add(*b);
+        };
+
+    for i in 0..16 {
+        f = (hash_b & hash_c) | (!hash_b & hash_d);
+        g = i;
+        cycle_hashes(&mut hash_a, &mut hash_b, &mut hash_c, &mut hash_d, f, g, i);
     }
-    state[0] = add!(state[0], a);
-    state[1] = add!(state[1], b);
-    state[2] = add!(state[2], c);
-    state[3] = add!(state[3], d);
+
+    for i in 16..32 {
+        f = (hash_d & hash_b) | (!hash_d & hash_c);
+        g = (5 * i + 1) % 16;
+        cycle_hashes(&mut hash_a, &mut hash_b, &mut hash_c, &mut hash_d, f, g, i);
+    }
+
+    for i in 32..48 {
+        f = hash_b ^ hash_c ^ hash_d;
+        g = (3 * i + 5) % 16;
+        cycle_hashes(&mut hash_a, &mut hash_b, &mut hash_c, &mut hash_d, f, g, i);
+    }
+
+    for i in 48..64 {
+        f = hash_c ^ (hash_b | !hash_d);
+        g = (7 * i) % 16;
+        cycle_hashes(&mut hash_a, &mut hash_b, &mut hash_c, &mut hash_d, f, g, i);
+    }
+
+    state[0] = state[0].wrapping_add(hash_a);
+    state[1] = state[1].wrapping_add(hash_b);
+    state[2] = state[2].wrapping_add(hash_c);
+    state[3] = state[3].wrapping_add(hash_d);
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,25 +278,25 @@ fn transform(state: &mut [u32; 4], buffer: &[u8; 64]) {
     for i in 0..16 {
         let f = (b & c) | (!b & d);
         let g = i;
-        cycle(&mut a, &mut b, &mut c, &mut d, f, segments[g], i);
+        rotate(&mut a, &mut b, &mut c, &mut d, f, segments[g], i);
     }
 
     for i in 16..32 {
         let f = (d & b) | (!d & c);
         let g = (5 * i + 1) % 16;
-        cycle(&mut a, &mut b, &mut c, &mut d, f, segments[g], i);
+        rotate(&mut a, &mut b, &mut c, &mut d, f, segments[g], i);
     }
 
     for i in 32..48 {
         let f = b ^ c ^ d;
         let g = (3 * i + 5) % 16;
-        cycle(&mut a, &mut b, &mut c, &mut d, f, segments[g], i);
+        rotate(&mut a, &mut b, &mut c, &mut d, f, segments[g], i);
     }
 
     for i in 48..64 {
         let f = c ^ (b | !d);
         let g = (7 * i) % 16;
-        cycle(&mut a, &mut b, &mut c, &mut d, f, segments[g], i);
+        rotate(&mut a, &mut b, &mut c, &mut d, f, segments[g], i);
     }
 
     state[0] = state[0].wrapping_add(a);
@@ -306,7 +306,7 @@ fn transform(state: &mut [u32; 4], buffer: &[u8; 64]) {
 }
 
 #[inline(always)]
-fn cycle(a: &mut u32, b: &mut u32, c: &mut u32, d: &mut u32, mut f: u32, g: u32, i: usize) {
+fn rotate(a: &mut u32, b: &mut u32, c: &mut u32, d: &mut u32, mut f: u32, g: u32, i: usize) {
     f = f.wrapping_add(*a).wrapping_add(SINES[i]).wrapping_add(g);
     *a = *d;
     *d = *c;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,6 @@ impl Context {
     }
 
     /// Finalize and return the digest.
-    #[inline]
     pub fn finalize(mut self) -> Digest {
         Digest(finalize(
             &mut self.state,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,9 +188,51 @@ impl core::io::Write for Context {
 /// Compute the digest of data.
 #[inline]
 pub fn compute<T: AsRef<[u8]>>(data: T) -> Digest {
-    let mut context = Context::new();
-    context.consume(data);
-    context.finalize()
+    // Code is explicitly inlined for performance.
+    let mut buffer: [u8; 64] = [0; 64];
+    let mut hash_values = START_HASH_VALUES;
+    let mut k = 0;
+
+    for &value in data.as_ref() {
+        buffer[k] = value;
+        k += 1;
+
+        if k == 64 {
+            transform(&mut hash_values, &buffer);
+            k = 0;
+        }
+    }
+
+    if k > 55 {
+        // Not enough space to fit length at the end of the buffer; pad and transform.
+        buffer[k..64].copy_from_slice(&PADDING[..64 - k]);
+        transform(&mut hash_values, &buffer);
+        // Copy across zeros upto the length marker.
+        buffer[..56].copy_from_slice(&PADDING[1..57])
+    } else {
+        // Enough space already; copy across padding.
+        buffer[k..56].copy_from_slice(&PADDING[..56 - k])
+    }
+
+    // Append the data length (in bits) and run the last transform.
+    let mut data_length = (data.as_ref().len() << 3) as u64;
+    let mut i = 0;
+    while i < 8 {
+        buffer[56 + i] = data_length as u8;
+        data_length >>= 8;
+        i += 1;
+    }
+
+    transform(&mut hash_values, &buffer);
+
+    let mut output: [u8; 16] = [0; 16];
+    // Convert hash_values from u32 -> u8s assuming little endian format.
+    for i in 0..16 {
+        output[i] = hash_values[i / 4] as u8;
+        hash_values[i / 4] >>= 8;
+    }
+
+    Digest(output)
 }
 
 fn consume_data(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,10 +188,12 @@ impl core::io::Write for Context {
 /// Compute the digest of data.
 #[allow(clippy::needless_range_loop)]
 pub fn compute<T: AsRef<[u8]>>(data: T) -> Digest {
-    let mut state = STATE;
-    let mut buffer: [u8; 64] = [0; 64];
-    let mut cursor = 0;
-    let mut length = 0;
+    let Context {
+        mut state,
+        mut buffer,
+        mut cursor,
+        mut length,
+    } = Context::new();
     let data = data.as_ref();
     consume(&mut state, &mut buffer, &mut cursor, &mut length, data);
     Digest(finalize(&mut state, &mut buffer, cursor, data.len() as u64))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,7 +192,6 @@ impl core::io::Write for Context {
 
 /// Compute the digest of data.
 #[allow(clippy::needless_range_loop)]
-#[inline]
 pub fn compute<T: AsRef<[u8]>>(data: T) -> Digest {
     let mut buffer: [u8; 64] = [0; 64];
     let mut state = STATE;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,7 +181,6 @@ impl core::io::Write for Context {
 }
 
 /// Compute the digest of data.
-#[allow(clippy::needless_range_loop)]
 pub fn compute<T: AsRef<[u8]>>(data: T) -> Digest {
     let (state, buffer, cursor, length) = consume(STATE, [0; 64], 0, 0, data.as_ref());
     finalize(state, buffer, cursor, length)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,9 +32,46 @@
 #[cfg(feature = "std")]
 use std as core;
 
+const STATE: [u32; 4] = [0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476];
+
+#[allow(clippy::zero_prefixed_literal)]
+#[rustfmt::skip]
+const SHIFTS: [u32; 64] = [
+    07, 12, 17, 22, 07, 12, 17, 22, 07, 12, 17, 22, 07, 12, 17, 22,
+    05, 09, 14, 20, 05, 09, 14, 20, 05, 09, 14, 20, 05, 09, 14, 20,
+    04, 11, 16, 23, 04, 11, 16, 23, 04, 11, 16, 23, 04, 11, 16, 23,
+    06, 10, 15, 21, 06, 10, 15, 21, 06, 10, 15, 21, 06, 10, 15, 21,
+];
+
+const SINES: [u32; 64] = [
+    0xd76aa478, 0xe8c7b756, 0x242070db, 0xc1bdceee, 0xf57c0faf, 0x4787c62a, 0xa8304613, 0xfd469501,
+    0x698098d8, 0x8b44f7af, 0xffff5bb1, 0x895cd7be, 0x6b901122, 0xfd987193, 0xa679438e, 0x49b40821,
+    0xf61e2562, 0xc040b340, 0x265e5a51, 0xe9b6c7aa, 0xd62f105d, 0x02441453, 0xd8a1e681, 0xe7d3fbc8,
+    0x21e1cde6, 0xc33707d6, 0xf4d50d87, 0x455a14ed, 0xa9e3e905, 0xfcefa3f8, 0x676f02d9, 0x8d2a4c8a,
+    0xfffa3942, 0x8771f681, 0x6d9d6122, 0xfde5380c, 0xa4beea44, 0x4bdecfa9, 0xf6bb4b60, 0xbebfbc70,
+    0x289b7ec6, 0xeaa127fa, 0xd4ef3085, 0x04881d05, 0xd9d4d039, 0xe6db99e5, 0x1fa27cf8, 0xc4ac5665,
+    0xf4292244, 0x432aff97, 0xab9423a7, 0xfc93a039, 0x655b59c3, 0x8f0ccc92, 0xffeff47d, 0x85845dd1,
+    0x6fa87e4f, 0xfe2ce6e0, 0xa3014314, 0x4e0811a1, 0xf7537e82, 0xbd3af235, 0x2ad7d2bb, 0xeb86d391,
+];
+
+const PADDING: [u8; 64] = {
+    let mut data = [0; 64];
+    data[0] = 0x80;
+    data
+};
+
 /// A digest.
 #[derive(Clone, Copy, Eq, Hash, PartialEq)]
 pub struct Digest(pub [u8; 16]);
+
+/// A context.
+#[derive(Clone)]
+pub struct Context {
+    state: [u32; 4],
+    buffer: [u8; 64],
+    cursor: usize,
+    length: u64,
+}
 
 impl core::convert::From<Digest> for [u8; 16] {
     #[inline]
@@ -81,44 +118,6 @@ macro_rules! implement {
 
 implement!(LowerHex, "{:02x}");
 implement!(UpperHex, "{:02X}");
-
-/// A context.
-#[derive(Clone)]
-pub struct Context {
-    state: [u32; 4],
-    buffer: [u8; 64],
-    cursor: usize,
-    length: u64,
-}
-
-const PADDING: [u8; 64] = {
-    let mut data = [0; 64];
-    data[0] = 0x80;
-    data
-};
-
-#[allow(clippy::zero_prefixed_literal)]
-#[rustfmt::skip]
-const SHIFTS: [u32; 64] = [
-    07, 12, 17, 22, 07, 12, 17, 22, 07, 12, 17, 22, 07, 12, 17, 22,
-    05, 09, 14, 20, 05, 09, 14, 20, 05, 09, 14, 20, 05, 09, 14, 20,
-    04, 11, 16, 23, 04, 11, 16, 23, 04, 11, 16, 23, 04, 11, 16, 23,
-    06, 10, 15, 21, 06, 10, 15, 21, 06, 10, 15, 21, 06, 10, 15, 21,
-];
-
-// f64::floor(power * f64::abs(f64::sin(i as f64 + 1.0))) as u32
-const SINES: [u32; 64] = [
-    0xd76aa478, 0xe8c7b756, 0x242070db, 0xc1bdceee, 0xf57c0faf, 0x4787c62a, 0xa8304613, 0xfd469501,
-    0x698098d8, 0x8b44f7af, 0xffff5bb1, 0x895cd7be, 0x6b901122, 0xfd987193, 0xa679438e, 0x49b40821,
-    0xf61e2562, 0xc040b340, 0x265e5a51, 0xe9b6c7aa, 0xd62f105d, 0x02441453, 0xd8a1e681, 0xe7d3fbc8,
-    0x21e1cde6, 0xc33707d6, 0xf4d50d87, 0x455a14ed, 0xa9e3e905, 0xfcefa3f8, 0x676f02d9, 0x8d2a4c8a,
-    0xfffa3942, 0x8771f681, 0x6d9d6122, 0xfde5380c, 0xa4beea44, 0x4bdecfa9, 0xf6bb4b60, 0xbebfbc70,
-    0x289b7ec6, 0xeaa127fa, 0xd4ef3085, 0x04881d05, 0xd9d4d039, 0xe6db99e5, 0x1fa27cf8, 0xc4ac5665,
-    0xf4292244, 0x432aff97, 0xab9423a7, 0xfc93a039, 0x655b59c3, 0x8f0ccc92, 0xffeff47d, 0x85845dd1,
-    0x6fa87e4f, 0xfe2ce6e0, 0xa3014314, 0x4e0811a1, 0xf7537e82, 0xbd3af235, 0x2ad7d2bb, 0xeb86d391,
-];
-
-const STATE: [u32; 4] = [0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476];
 
 impl Context {
     /// Create a context for computing a digest.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,7 +189,13 @@ pub fn compute<T: AsRef<[u8]>>(data: T) -> Digest {
         mut cursor,
         mut length,
     } = Context::new();
-    consume(&mut state, &mut buffer, &mut cursor, &mut length, data.as_ref());
+    consume(
+        &mut state,
+        &mut buffer,
+        &mut cursor,
+        &mut length,
+        data.as_ref(),
+    );
     finalize(&mut state, &mut buffer, cursor, length)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,9 +189,8 @@ pub fn compute<T: AsRef<[u8]>>(data: T) -> Digest {
         mut cursor,
         mut length,
     } = Context::new();
-    let data = data.as_ref();
-    consume(&mut state, &mut buffer, &mut cursor, &mut length, data);
-    finalize(&mut state, &mut buffer, cursor, data.len() as u64)
+    consume(&mut state, &mut buffer, &mut cursor, &mut length, data.as_ref());
+    finalize(&mut state, &mut buffer, cursor, length)
 }
 
 #[inline(always)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,8 +207,8 @@ fn consume(
     length: &mut u64,
     data: &[u8],
 ) {
-    for chunk in data {
-        buffer[*cursor] = *chunk;
+    for value in data {
+        buffer[*cursor] = *value;
         *cursor += 1;
         if *cursor == 64 {
             transform(state, buffer);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,7 +246,7 @@ fn finalize(
     output
 }
 
-#[allow(clippy::identity_op, clippy::needless_range_loop)]
+#[allow(clippy::double_parens, clippy::needless_range_loop)]
 #[inline(always)]
 #[rustfmt::skip]
 fn transform(state: &mut [u32; 4], buffer: &[u8; 64]) {
@@ -255,7 +255,7 @@ fn transform(state: &mut [u32; 4], buffer: &[u8; 64]) {
     for i in 0..16 {
         let j = i * 4;
         segments[i] =
-              ((buffer[j + 0] as u32) <<  0)
+              ((buffer[j    ] as u32)      )
             + ((buffer[j + 1] as u32) <<  8)
             + ((buffer[j + 2] as u32) << 16)
             + ((buffer[j + 3] as u32) << 24);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,7 @@ const PADDING: [u8; 64] = {
     data
 };
 
+#[allow(clippy::zero_prefixed_literal)]
 #[rustfmt::skip]
 const SHIFTS: [u32; 64] = [
     07, 12, 17, 22, 07, 12, 17, 22, 07, 12, 17, 22, 07, 12, 17, 22,
@@ -182,6 +183,7 @@ impl core::io::Write for Context {
 }
 
 /// Compute the digest of data.
+#[allow(clippy::needless_range_loop)]
 #[inline]
 pub fn compute<T: AsRef<[u8]>>(data: T) -> Digest {
     let mut buffer: [u8; 64] = [0; 64];
@@ -226,19 +228,20 @@ fn consume(buffer: &mut [u8; 64], count: &mut [u32; 2], state: &mut [u32; 4], da
         buffer[cursor as usize] = *chunk;
         cursor += 1;
         if cursor == 64 {
-            transform(state, &buffer);
+            transform(state, buffer);
             cursor = 0;
         }
     }
     increment(count, data.len() as u64);
 }
 
+#[allow(clippy::needless_range_loop)]
 #[inline(always)]
 fn finalize(buffer: &mut [u8; 64], count: &[u32; 2], state: &mut [u32; 4]) -> [u8; 16] {
     let cursor = (count[0] % 64) as usize;
     if cursor > 55 {
         buffer[cursor..64].copy_from_slice(&PADDING[..64 - cursor]);
-        transform(state, &buffer);
+        transform(state, buffer);
         buffer[0..56].copy_from_slice(&PADDING[1..57])
     } else {
         buffer[cursor..56].copy_from_slice(&PADDING[..56 - cursor])
@@ -248,7 +251,7 @@ fn finalize(buffer: &mut [u8; 64], count: &[u32; 2], state: &mut [u32; 4]) -> [u
         buffer[i] = length as u8;
         length >>= 8;
     }
-    transform(state, &buffer);
+    transform(state, buffer);
 
     let mut output: [u8; 16] = [0; 16];
     for i in 0..16 {
@@ -266,8 +269,9 @@ fn increment(count: &mut [u32; 2], addition: u64) {
     count[1] = (length >> 32) as u32;
 }
 
-#[rustfmt::skip]
+#[allow(clippy::identity_op, clippy::needless_range_loop)]
 #[inline(always)]
+#[rustfmt::skip]
 fn transform(state: &mut [u32; 4], buffer: &[u8; 64]) {
     let mut segments: [u32; 16] = [0; 16];
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,9 +24,6 @@
 //! [RFC6151]: https://tools.ietf.org/html/rfc6151
 //! [VU836068]: https://www.kb.cert.org/vuls/id/836068
 
-// The implementation is based on:
-// https://www.ietf.org/rfc/rfc1321.txt
-
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(feature = "std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,9 +85,10 @@ implement!(UpperHex, "{:02X}");
 /// A context.
 #[derive(Clone)]
 pub struct Context {
-    buffer: [u8; 64],
-    count: [u32; 2],
     state: [u32; 4],
+    buffer: [u8; 64],
+    cursor: usize,
+    length: u64,
 }
 
 const PADDING: [u8; 64] = {
@@ -124,33 +125,33 @@ impl Context {
     #[inline]
     pub fn new() -> Context {
         Context {
-            buffer: [0; 64],
-            count: [0, 0],
             state: STATE,
+            buffer: [0; 64],
+            cursor: 0,
+            length: 0,
         }
     }
 
     /// Consume data.
     pub fn consume<T: AsRef<[u8]>>(&mut self, data: T) {
         consume(
-            &mut self.buffer,
-            &mut self.count,
             &mut self.state,
+            &mut self.buffer,
+            &mut self.cursor,
+            &mut self.length,
             data.as_ref(),
         );
     }
 
     /// Finalize and return the digest.
     #[inline]
-    pub fn finalize(self) -> Digest {
-        let Context {
-            mut buffer,
-            count,
-            mut state,
-        } = self;
-        let cursor = (count[0] % 64) as usize;
-        let length = (count[0] as u64 | ((count[1] as u64) << 32)) << 3;
-        Digest(finalize(&mut buffer, &mut state, cursor, length))
+    pub fn finalize(mut self) -> Digest {
+        Digest(finalize(
+            &mut self.state,
+            &mut self.buffer,
+            self.cursor,
+            self.length,
+        ))
     }
 
     /// Finalize and return the digest.
@@ -207,33 +208,33 @@ pub fn compute<T: AsRef<[u8]>>(data: T) -> Digest {
         }
     }
 
-    Digest(finalize(
-        &mut buffer,
-        &mut state,
-        cursor,
-        (data.len() << 3) as u64,
-    ))
+    Digest(finalize(&mut state, &mut buffer, cursor, data.len() as u64))
 }
 
 #[inline(always)]
-fn consume(buffer: &mut [u8; 64], count: &mut [u32; 2], state: &mut [u32; 4], data: &[u8]) {
-    let mut cursor = count[0] % 64;
+fn consume(
+    state: &mut [u32; 4],
+    buffer: &mut [u8; 64],
+    cursor: &mut usize,
+    length: &mut u64,
+    data: &[u8],
+) {
     for chunk in data {
-        buffer[cursor as usize] = *chunk;
-        cursor += 1;
-        if cursor == 64 {
+        buffer[*cursor] = *chunk;
+        *cursor += 1;
+        if *cursor == 64 {
             transform(state, buffer);
-            cursor = 0;
+            *cursor = 0;
         }
     }
-    increment(count, data.len() as u64);
+    *length = length.wrapping_add(data.len() as u64);
 }
 
 #[allow(clippy::needless_range_loop)]
 #[inline(always)]
 fn finalize(
-    buffer: &mut [u8; 64],
     state: &mut [u32; 4],
+    buffer: &mut [u8; 64],
     cursor: usize,
     mut length: u64,
 ) -> [u8; 16] {
@@ -244,6 +245,7 @@ fn finalize(
     } else {
         buffer[cursor..56].copy_from_slice(&PADDING[..56 - cursor])
     }
+    length <<= 3;
     for i in 56..64 {
         buffer[i] = length as u8;
         length >>= 8;
@@ -256,14 +258,6 @@ fn finalize(
         state[i / 4] >>= 8;
     }
     output
-}
-
-#[inline(always)]
-fn increment(count: &mut [u32; 2], addition: u64) {
-    let length = count[0] as u64 | ((count[1] as u64) << 32);
-    let length = length.wrapping_add(addition);
-    count[0] = length as u32;
-    count[1] = (length >> 32) as u32;
 }
 
 #[allow(clippy::identity_op, clippy::needless_range_loop)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,17 +224,15 @@ fn finalize(mut state: [u32; 4], mut buffer: [u8; 64], cursor: usize, mut length
     Digest(value)
 }
 
-#[allow(clippy::double_parens, clippy::needless_range_loop)]
+#[allow(clippy::needless_range_loop)]
 #[inline(always)]
-#[rustfmt::skip]
 fn transform(state: &mut [u32; 4], buffer: &[u8; 64]) {
     let buffer = {
         let mut value: [u32; 16] = [0; 16];
         for i in 0..16 {
             let j = i * 4;
-            value[i] =
-                  ((buffer[j    ] as u32)      )
-                + ((buffer[j + 1] as u32) <<  8)
+            value[i] = (buffer[j] as u32)
+                + ((buffer[j + 1] as u32) << 8)
                 + ((buffer[j + 2] as u32) << 16)
                 + ((buffer[j + 3] as u32) << 24);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,20 +224,9 @@ fn finalize(mut state: [u32; 4], mut buffer: [u8; 64], cursor: usize, mut length
     Digest(value)
 }
 
-#[allow(clippy::needless_range_loop)]
 #[inline(always)]
 fn transform(state: &mut [u32; 4], buffer: &[u8; 64]) {
-    let buffer = {
-        let mut value: [u32; 16] = [0; 16];
-        for i in 0..16 {
-            let j = i * 4;
-            value[i] = (buffer[j] as u32)
-                + ((buffer[j + 1] as u32) << 8)
-                + ((buffer[j + 2] as u32) << 16)
-                + ((buffer[j + 3] as u32) << 24);
-        }
-        value
-    };
+    let buffer = convert(buffer);
 
     let mut a = state[0];
     let mut b = state[1];
@@ -272,6 +261,20 @@ fn transform(state: &mut [u32; 4], buffer: &[u8; 64]) {
     state[1] = state[1].wrapping_add(b);
     state[2] = state[2].wrapping_add(c);
     state[3] = state[3].wrapping_add(d);
+}
+
+#[allow(clippy::needless_range_loop)]
+#[inline(always)]
+fn convert(buffer: &[u8; 64]) -> [u32; 16] {
+    let mut value: [u32; 16] = [0; 16];
+    for i in 0..16 {
+        let j = i * 4;
+        value[i] = (buffer[j] as u32)
+            + ((buffer[j + 1] as u32) << 8)
+            + ((buffer[j + 2] as u32) << 16)
+            + ((buffer[j + 3] as u32) << 24);
+    }
+    value
 }
 
 #[inline(always)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,14 +136,9 @@ impl Context {
     }
 
     /// Finalize and return the digest.
+    #[inline]
     pub fn finalize(mut self) -> Digest {
-        consume_final_bits(&mut self);
-        let mut output: [u8; 16] = [0; 16];
-        for i in 0..16 {
-            output[i] = self.state[i / 4] as u8;
-            self.state[i / 4] >>= 8;
-        }
-        Digest(output)
+        Digest(finalize(&mut self))
     }
 
     /// Finalize and return the digest.
@@ -257,13 +252,13 @@ fn consume(
     count[1] = (new_count >> 32) as u32;
 }
 
-fn consume_final_bits(
+fn finalize(
     Context {
         buffer,
         count,
         state,
     }: &mut Context,
-) {
+) -> [u8; 16] {
     let cursor = (count[0] % 64) as usize;
 
     if cursor > 55 {
@@ -285,6 +280,14 @@ fn consume_final_bits(
     }
 
     transform(state, &buffer);
+
+    let mut output: [u8; 16] = [0; 16];
+    for i in 0..16 {
+        output[i] = state[i / 4] as u8;
+        state[i / 4] >>= 8;
+    }
+
+    output
 }
 
 #[rustfmt::skip]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,10 +98,10 @@ const PADDING: [u8; 64] = {
 
 #[rustfmt::skip]
 const SHIFTS: [u32; 64] = [
-    07, 12, 17, 22, 07, 12, 17, 22, 07, 12, 17, 22, 07, 12, 17, 22, // Round 1
-    05, 09, 14, 20, 05, 09, 14, 20, 05, 09, 14, 20, 05, 09, 14, 20, // Round 2
-    04, 11, 16, 23, 04, 11, 16, 23, 04, 11, 16, 23, 04, 11, 16, 23, // Round 3
-    06, 10, 15, 21, 06, 10, 15, 21, 06, 10, 15, 21, 06, 10, 15, 21, // Round 4
+    07, 12, 17, 22, 07, 12, 17, 22, 07, 12, 17, 22, 07, 12, 17, 22,
+    05, 09, 14, 20, 05, 09, 14, 20, 05, 09, 14, 20, 05, 09, 14, 20,
+    04, 11, 16, 23, 04, 11, 16, 23, 04, 11, 16, 23, 04, 11, 16, 23,
+    06, 10, 15, 21, 06, 10, 15, 21, 06, 10, 15, 21, 06, 10, 15, 21,
 ];
 
 // f64::floor(power * f64::abs(f64::sin(i as f64 + 1.0))) as u32
@@ -116,7 +116,7 @@ const SINES: [u32; 64] = [
     0x6fa87e4f, 0xfe2ce6e0, 0xa3014314, 0x4e0811a1, 0xf7537e82, 0xbd3af235, 0x2ad7d2bb, 0xeb86d391,
 ];
 
-const START_HASH_VALUES: [u32; 4] = [0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476];
+const STATE: [u32; 4] = [0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476];
 
 impl Context {
     /// Create a context for computing a digest.
@@ -125,27 +125,24 @@ impl Context {
         Context {
             buffer: [0; 64],
             count: [0, 0],
-            state: START_HASH_VALUES,
+            state: STATE,
         }
     }
 
     /// Consume data.
     #[inline]
     pub fn consume<T: AsRef<[u8]>>(&mut self, data: T) {
-        consume_data(self, data.as_ref());
+        consume(self, data.as_ref());
     }
 
     /// Finalize and return the digest.
     pub fn finalize(mut self) -> Digest {
         consume_final_bits(&mut self);
-
         let mut output: [u8; 16] = [0; 16];
-        // Convert hash_values from u32 -> u8s assuming little endian format.
         for i in 0..16 {
             output[i] = self.state[i / 4] as u8;
             self.state[i / 4] >>= 8;
         }
-
         Digest(output)
     }
 
@@ -188,17 +185,15 @@ impl core::io::Write for Context {
 /// Compute the digest of data.
 #[inline]
 pub fn compute<T: AsRef<[u8]>>(data: T) -> Digest {
-    // Code is explicitly inlined for performance.
     let mut buffer: [u8; 64] = [0; 64];
-    let mut hash_values = START_HASH_VALUES;
+    let mut state = STATE;
     let mut k = 0;
 
     for &value in data.as_ref() {
         buffer[k] = value;
         k += 1;
-
         if k == 64 {
-            transform(&mut hash_values, &buffer);
+            transform(&mut state, &buffer);
             k = 0;
         }
     }
@@ -206,7 +201,7 @@ pub fn compute<T: AsRef<[u8]>>(data: T) -> Digest {
     if k > 55 {
         // Not enough space to fit length at the end of the buffer; pad and transform.
         buffer[k..64].copy_from_slice(&PADDING[..64 - k]);
-        transform(&mut hash_values, &buffer);
+        transform(&mut state, &buffer);
         // Copy across zeros upto the length marker.
         buffer[..56].copy_from_slice(&PADDING[1..57])
     } else {
@@ -223,19 +218,18 @@ pub fn compute<T: AsRef<[u8]>>(data: T) -> Digest {
         i += 1;
     }
 
-    transform(&mut hash_values, &buffer);
+    transform(&mut state, &buffer);
 
     let mut output: [u8; 16] = [0; 16];
-    // Convert hash_values from u32 -> u8s assuming little endian format.
     for i in 0..16 {
-        output[i] = hash_values[i / 4] as u8;
-        hash_values[i / 4] >>= 8;
+        output[i] = state[i / 4] as u8;
+        state[i / 4] >>= 8;
     }
 
     Digest(output)
 }
 
-fn consume_data(
+fn consume(
     Context {
         buffer,
         count,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,20 +188,12 @@ impl core::io::Write for Context {
 /// Compute the digest of data.
 #[allow(clippy::needless_range_loop)]
 pub fn compute<T: AsRef<[u8]>>(data: T) -> Digest {
-    let mut buffer: [u8; 64] = [0; 64];
     let mut state = STATE;
+    let mut buffer: [u8; 64] = [0; 64];
     let mut cursor = 0;
-
+    let mut length = 0;
     let data = data.as_ref();
-    for &value in data {
-        buffer[cursor] = value;
-        cursor += 1;
-        if cursor == 64 {
-            transform(&mut state, &buffer);
-            cursor = 0;
-        }
-    }
-
+    consume(&mut state, &mut buffer, &mut cursor, &mut length, data);
     Digest(finalize(&mut state, &mut buffer, cursor, data.len() as u64))
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,16 +252,18 @@ fn finalize(
 #[inline(always)]
 #[rustfmt::skip]
 fn transform(state: &mut [u32; 4], buffer: &[u8; 64]) {
-    let mut segments: [u32; 16] = [0; 16];
-
-    for i in 0..16 {
-        let j = i * 4;
-        segments[i] =
-              ((buffer[j    ] as u32)      )
-            + ((buffer[j + 1] as u32) <<  8)
-            + ((buffer[j + 2] as u32) << 16)
-            + ((buffer[j + 3] as u32) << 24);
-    }
+    let buffer = {
+        let mut value: [u32; 16] = [0; 16];
+        for i in 0..16 {
+            let j = i * 4;
+            value[i] =
+                  ((buffer[j    ] as u32)      )
+                + ((buffer[j + 1] as u32) <<  8)
+                + ((buffer[j + 2] as u32) << 16)
+                + ((buffer[j + 3] as u32) << 24);
+        }
+        value
+    };
 
     let mut a = state[0];
     let mut b = state[1];
@@ -271,25 +273,25 @@ fn transform(state: &mut [u32; 4], buffer: &[u8; 64]) {
     for i in 0..16 {
         let f = (b & c) | (!b & d);
         let g = i;
-        rotate(&mut a, &mut b, &mut c, &mut d, f, segments[g], i);
+        rotate(&mut a, &mut b, &mut c, &mut d, f, buffer[g], i);
     }
 
     for i in 16..32 {
         let f = (d & b) | (!d & c);
         let g = (5 * i + 1) % 16;
-        rotate(&mut a, &mut b, &mut c, &mut d, f, segments[g], i);
+        rotate(&mut a, &mut b, &mut c, &mut d, f, buffer[g], i);
     }
 
     for i in 32..48 {
         let f = b ^ c ^ d;
         let g = (3 * i + 5) % 16;
-        rotate(&mut a, &mut b, &mut c, &mut d, f, segments[g], i);
+        rotate(&mut a, &mut b, &mut c, &mut d, f, buffer[g], i);
     }
 
     for i in 48..64 {
         let f = c ^ (b | !d);
         let g = (7 * i) % 16;
-        rotate(&mut a, &mut b, &mut c, &mut d, f, segments[g], i);
+        rotate(&mut a, &mut b, &mut c, &mut d, f, buffer[g], i);
     }
 
     state[0] = state[0].wrapping_add(a);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,12 +141,12 @@ impl Context {
 
     /// Finalize and return the digest.
     pub fn finalize(mut self) -> Digest {
-        Digest(finalize(
+        finalize(
             &mut self.state,
             &mut self.buffer,
             self.cursor,
             self.length,
-        ))
+        )
     }
 
     /// Finalize and return the digest.
@@ -196,7 +196,7 @@ pub fn compute<T: AsRef<[u8]>>(data: T) -> Digest {
     } = Context::new();
     let data = data.as_ref();
     consume(&mut state, &mut buffer, &mut cursor, &mut length, data);
-    Digest(finalize(&mut state, &mut buffer, cursor, data.len() as u64))
+    finalize(&mut state, &mut buffer, cursor, data.len() as u64)
 }
 
 #[inline(always)]
@@ -225,7 +225,7 @@ fn finalize(
     buffer: &mut [u8; 64],
     cursor: usize,
     mut length: u64,
-) -> [u8; 16] {
+) -> Digest {
     if cursor > 55 {
         buffer[cursor..64].copy_from_slice(&PADDING[..64 - cursor]);
         transform(state, buffer);
@@ -240,12 +240,12 @@ fn finalize(
     }
     transform(state, buffer);
 
-    let mut output: [u8; 16] = [0; 16];
+    let mut value: [u8; 16] = [0; 16];
     for i in 0..16 {
-        output[i] = state[i / 4] as u8;
+        value[i] = state[i / 4] as u8;
         state[i / 4] >>= 8;
     }
-    output
+    Digest(value)
 }
 
 #[allow(clippy::double_parens, clippy::needless_range_loop)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,12 +141,7 @@ impl Context {
 
     /// Finalize and return the digest.
     pub fn finalize(mut self) -> Digest {
-        finalize(
-            &mut self.state,
-            &mut self.buffer,
-            self.cursor,
-            self.length,
-        )
+        finalize(&mut self.state, &mut self.buffer, self.cursor, self.length)
     }
 
     /// Finalize and return the digest.
@@ -220,12 +215,7 @@ fn consume(
 
 #[allow(clippy::needless_range_loop)]
 #[inline(always)]
-fn finalize(
-    state: &mut [u32; 4],
-    buffer: &mut [u8; 64],
-    cursor: usize,
-    mut length: u64,
-) -> Digest {
+fn finalize(state: &mut [u32; 4], buffer: &mut [u8; 64], cursor: usize, mut length: u64) -> Digest {
     if cursor > 55 {
         buffer[cursor..64].copy_from_slice(&PADDING[..64 - cursor]);
         transform(state, buffer);


### PR DESCRIPTION
# macOS, ARM64

Main:

```
test compute_0001000 ... bench:       1,696 ns/iter (+/- 12)
test compute_0010000 ... bench:      16,578 ns/iter (+/- 162)
test compute_0100000 ... bench:     164,988 ns/iter (+/- 2,065)
test compute_1000000 ... bench:   1,649,850 ns/iter (+/- 10,186)
test context_0001000 ... bench:       1,697 ns/iter (+/- 16)
test context_0010000 ... bench:      16,582 ns/iter (+/- 203)
test context_0100000 ... bench:     165,100 ns/iter (+/- 2,997)
test context_1000000 ... bench:   1,652,079 ns/iter (+/- 39,340)
```

This PR:

```
test compute_0001000 ... bench:       2,088 ns/iter (+/- 26)
test compute_0010000 ... bench:      20,554 ns/iter (+/- 1,331)
test compute_0100000 ... bench:     204,522 ns/iter (+/- 4,461)
test compute_1000000 ... bench:   2,045,050 ns/iter (+/- 8,309)
test context_0001000 ... bench:       2,226 ns/iter (+/- 17)
test context_0010000 ... bench:      21,832 ns/iter (+/- 449)
test context_0100000 ... bench:     217,379 ns/iter (+/- 6,678)
test context_1000000 ... bench:   2,173,283 ns/iter (+/- 18,401)
```

# Linux, AMD64

Main:

```
test compute_0001000 ... bench:       2,370 ns/iter (+/- 19)
test compute_0010000 ... bench:      23,144 ns/iter (+/- 4,352)
test compute_0100000 ... bench:     230,255 ns/iter (+/- 1,556)
test compute_1000000 ... bench:   2,299,363 ns/iter (+/- 6,198)
test context_0001000 ... bench:       2,368 ns/iter (+/- 32)
test context_0010000 ... bench:      23,136 ns/iter (+/- 101)
test context_0100000 ... bench:     230,174 ns/iter (+/- 760)
test context_1000000 ... bench:   2,302,334 ns/iter (+/- 8,662)
```

This PR:

```
test compute_0001000 ... bench:       1,790 ns/iter (+/- 14)
test compute_0010000 ... bench:      17,532 ns/iter (+/- 106)
test compute_0100000 ... bench:     174,332 ns/iter (+/- 572)
test compute_1000000 ... bench:   1,745,888 ns/iter (+/- 5,770)
test context_0001000 ... bench:       2,163 ns/iter (+/- 13)
test context_0010000 ... bench:      21,208 ns/iter (+/- 274)
test context_0100000 ... bench:     211,190 ns/iter (+/- 2,317)
test context_1000000 ... bench:   2,037,844 ns/iter (+/- 5,788)
```